### PR TITLE
Fix of PerforceBlameCommand to analyse "have" revision

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceBlameCommand.java
@@ -53,8 +53,7 @@ public class PerforceBlameCommand extends BlameCommand {
     try {
       for (InputFile inputFile : input.filesToBlame()) {
         PerforceBlameResult p4Result = new PerforceBlameResult();
-        List<IFileSpec> fileSpecs = FileSpecBuilder
-          .makeFileSpecList(new String[] {PerforceExecutor.encodeWildcards(inputFile.absolutePath())});
+        List<IFileSpec> fileSpecs = createFileSpec(inputFile);
         try {
           // Get file annotations
           GetFileAnnotationsOptions getFileAnnotationsOptions = new GetFileAnnotationsOptions();
@@ -86,6 +85,19 @@ public class PerforceBlameCommand extends BlameCommand {
     } finally {
       executor.clean();
     }
+  }
+
+  /**
+   * Creates file spec for the specified file taking into an account that we are interested in a revision that we have
+   * in the current client workspace.
+   * @param inputFile file to create file spec for
+   * @return list of file specs containing the only one spec for the specified file.
+   */
+  private List<IFileSpec> createFileSpec(InputFile inputFile) {
+    List<IFileSpec> fileSpecs = FileSpecBuilder
+      .makeFileSpecList(new String[]{PerforceExecutor.encodeWildcards(inputFile.absolutePath())});
+    fileSpecs.get(0).setEndRevision(IFileSpec.HAVE_REVISION);
+    return fileSpecs;
   }
 
 }


### PR DESCRIPTION
Before the change blame was return for the head revision. For big projects files in perforce could be changed during analysis. That was the reason why analysed file had different numbers of lines then the file a blame information was returned for. Analysis failed and could not finished successfully because of that.

 The change sets for a file spec "have" revision so that the blame information is returned for the files that are in perforce workspace during analysis.