### PR TITLE
Make socket read timeout configurable via sonar.perforce.sockSoTimeout.

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceConfiguration.java
@@ -20,6 +20,7 @@
 package org.sonar.plugins.scm.perforce;
 
 import com.google.common.collect.ImmutableList;
+import com.perforce.p4java.impl.mapbased.rpc.RpcPropertyDefs;
 import org.sonar.api.BatchComponent;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.PropertyType;
@@ -43,6 +44,7 @@ public class PerforceConfiguration implements BatchComponent {
   private static final String PASSWORD_PROP_KEY = "sonar.perforce.password.secured";
   static final String CLIENT_PROP_KEY = "sonar.perforce.clientName";
   private static final String CHARSET_PROP_KEY = "sonar.perforce.charset";
+  private static final String SOCKSOTIMEOUT_PROP_KEY = "sonar.perforce.sockSoTimeout";
 
   private final Settings settings;
 
@@ -105,6 +107,15 @@ public class PerforceConfiguration implements BatchComponent {
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_PERFORCE)
         .index(5)
+        .build(),
+      PropertyDefinition.builder(SOCKSOTIMEOUT_PROP_KEY)
+        .name("Perforce socket read timeout")
+        .description("Sets the socket read timeout for communicating with the Perforce service (milliseconds)")
+        .type(PropertyType.INTEGER)
+        .defaultValue(String.valueOf(RpcPropertyDefs.RPC_SOCKET_SO_TIMEOUT_DEFAULT))
+        .category(CoreProperties.CATEGORY_SCM)
+        .subCategory(CATEGORY_PERFORCE)
+        .index(6)
         .build());
   }
 
@@ -135,6 +146,10 @@ public class PerforceConfiguration implements BatchComponent {
   @CheckForNull
   public String clientName() {
     return settings.getString(CLIENT_PROP_KEY);
+  }
+
+  public int sockSoTimeout() {
+    return settings.getInt(SOCKSOTIMEOUT_PROP_KEY);
   }
 
 }

--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
@@ -27,6 +27,7 @@ import com.perforce.p4java.exception.MessageSeverityCode;
 import com.perforce.p4java.exception.P4JavaException;
 import com.perforce.p4java.impl.generic.client.ClientView;
 import com.perforce.p4java.impl.generic.client.ClientView.ClientViewMapping;
+import com.perforce.p4java.impl.mapbased.rpc.RpcPropertyDefs;
 import com.perforce.p4java.impl.mapbased.rpc.sys.helper.RpcSystemFileCommandsHelper;
 import com.perforce.p4java.option.server.TrustOptions;
 import com.perforce.p4java.server.IOptionsServer;
@@ -36,6 +37,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -180,11 +182,13 @@ public class PerforceExecutor {
     if (StringUtils.isEmpty(config.port())) {
       throw MessageException.of("Please configure perforce port using " + PerforceConfiguration.PORT_PROP_KEY);
     }
+    Properties props = new Properties();
+    props.put(RpcPropertyDefs.RPC_SOCKET_SO_TIMEOUT_NICK, config.sockSoTimeout());
     if (config.useSsl()) {
-      server = ServerFactory.getOptionsServer("p4javassl://" + config.port(), null, null);
+      server = ServerFactory.getOptionsServer("p4javassl://" + config.port(), props, null);
       server.addTrust(new TrustOptions().setAutoAccept(true));
     } else {
-      server = ServerFactory.getOptionsServer("p4java://" + config.port(), null, null);
+      server = ServerFactory.getOptionsServer("p4java://" + config.port(), props, null);
     }
     // Register server callback.
     server.registerCallback(new CommandLogger());

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceConfigurationTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.scm.perforce;
 
+import com.perforce.p4java.impl.mapbased.rpc.RpcPropertyDefs;
 import org.junit.Test;
 import org.sonar.api.config.PropertyDefinitions;
 import org.sonar.api.config.Settings;
@@ -38,5 +39,6 @@ public class PerforceConfigurationTest {
     assertThat(config.username()).isNull();
     assertThat(config.password()).isNull();
     assertThat(config.useSsl()).isFalse();
+    assertThat(config.sockSoTimeout()).isEqualTo(RpcPropertyDefs.RPC_SOCKET_SO_TIMEOUT_DEFAULT);
   }
 }


### PR DESCRIPTION
During blame, user may encounter "java.net.SocketTimeoutException: Read
timed out" if a command takes longer than the default 30 seconds that
is set by p4java.  This could easily occur when connecting to a Perforce
repository that is part of a proxy configuration which does not have the
blame information cached at time of SonarQube analysis.